### PR TITLE
Updated app to use to use character key instead of position in models

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -25,8 +25,8 @@
     <tr *ngFor="let player of players; let i=index" [attr.data-index]="i">
       <td>{{ i + 1 }}</td>
       <td>{{ player.name }}</td>
-      <td>{{ characters[player.position - 1].name }}</td>
-      <td>{{ (player.position / characters.length) * 100 | number }}%</td>
+      <td>{{ findCurrentCharacterName(player) }}</td>
+      <td>{{ calculateProgress(player) | number }}%</td>
     </tr>
     </tbody>
   </table>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -14,12 +14,27 @@ export class AppComponent implements OnInit {
   constructor(private dataService: DataService) { }
 
   ngOnInit() {
-    this.dataService.getCharacters().subscribe(characters => this.characters = characters);
-    this.dataService.getPlayers().subscribe(players => {
-      players.sort((a, b) => {
-        return a.position < b.position ? 1 : -1;
+    this.dataService.getCharacters().subscribe(characters => {
+      this.characters = characters;
+      this.dataService.getPlayers().subscribe(players => {
+        players.sort((a, b) => {
+          const currentCharacterA = characters.find(c => c.key === a.character);
+          const currentCharacterB = characters.find(c => c.key === b.character);
+          return currentCharacterA.order < currentCharacterB.order ? 1 : -1;
+        });
+        this.players = players;
       });
-      this.players = players;
     });
   }
+
+  findCurrentCharacterName(player: Player): string {
+    const playerCharacter = this.characters.find(char => char.key === player.character);
+    return playerCharacter.name;
+  }
+
+  calculateProgress(player: Player): number {
+    const playerCharacter = this.characters.find(char => char.key === player.character);
+    return (playerCharacter.order / this.characters.length) * 100;
+  }
+
 }

--- a/src/app/models.ts
+++ b/src/app/models.ts
@@ -7,5 +7,5 @@ class Character {
 class Player {
   id: number;
   name: string;
-  position: number;
+  character: string;
 }

--- a/src/assets/players.json
+++ b/src/assets/players.json
@@ -2,31 +2,31 @@
   {
     "id": 1,
     "name": "Alex Dykstra",
-    "position": 12
+    "character": "captain-falcon"
   },
   {
     "id": 2,
     "name": "Austin Anderson",
-    "position": 8
+    "character": "fox"
   },
   {
     "id": 3,
     "name": "Long Le",
-    "position": 7
+    "character": "kirby"
   },
   {
     "id": 4,
     "name": "Brandon Smith",
-    "position": 5
+    "character": "dark-samus"
   },
   {
     "id": 5,
     "name": "Torey Mercurio",
-    "position": 2
+    "character": "donkey-kong"
   },
   {
     "id": 6,
     "name": "Bryan Healy",
-    "position": 3
+    "character": "link"
   }
 ]


### PR DESCRIPTION
You can now put in the character's key instead of it's position in the Player's data. I think this would be easier instead of counting which position a character is in the overall list.